### PR TITLE
fix: 修复播放列表歌名显示异常问题

### DIFF
--- a/src/store/play-list.ts
+++ b/src/store/play-list.ts
@@ -10,6 +10,7 @@ import { immer } from "zustand/middleware/immer";
 import { getPlayModeList, PlayMode } from "@/common/constants/audio";
 import { getAudioUrl, getDashUrl, isUrlValid } from "@/common/utils/audio";
 import { beginPlayReport, endPlayReport, reportHeartbeat } from "@/common/utils/play-report";
+import { stripHtml } from "@/common/utils/str";
 import { formatUrlProtocol } from "@/common/utils/url";
 import { getAudioSongInfo } from "@/service/audio-song-info";
 import { getWebInterfaceView } from "@/service/web-interface-view";
@@ -171,6 +172,8 @@ const toastError = (title: string) => {
     color: "danger",
   });
 };
+
+const sanitizeTitle = (title: string) => stripHtml(title);
 
 const handlePlayError = (error: any) => {
   const errorMsg = error?.message || error?.name || "";
@@ -531,6 +534,7 @@ export const usePlayList = create<State & Action>()(
         play: async ({ type, bvid, sid, title, cover, ownerName, ownerMid }: PlayItem) => {
           const { list, playId } = get();
           const currentItem = list?.find(item => item.id === playId);
+          const sanitizedTitle = sanitizeTitle(title);
 
           // 当前正在播放，如果暂停了则播放
           if (isSame(currentItem, { type, bvid, sid })) {
@@ -555,7 +559,7 @@ export const usePlayList = create<State & Action>()(
               type,
               bvid,
               sid,
-              title,
+              title: sanitizedTitle,
               cover: cover ? formatUrlProtocol(cover) : undefined,
               ownerName,
               ownerMid,
@@ -598,6 +602,7 @@ export const usePlayList = create<State & Action>()(
         playList: async items => {
           const newList = items.map(item => ({
             ...item,
+            title: sanitizeTitle(item.title),
             id: idGenerator(),
           }));
 
@@ -699,6 +704,7 @@ export const usePlayList = create<State & Action>()(
         addToNext: async ({ type, title, bvid, sid, cover, ownerName, ownerMid }) => {
           const { playId, nextId: currentNextId, list } = get();
           const currentItem = list.find(item => item.id === playId);
+          const sanitizedTitle = sanitizeTitle(title);
           // 如果当前正在播放，则不添加
           if (isSame({ type, bvid, sid }, currentItem)) {
             return;
@@ -733,7 +739,7 @@ export const usePlayList = create<State & Action>()(
               type,
               bvid,
               sid,
-              title,
+              title: sanitizedTitle,
               cover: cover ? formatUrlProtocol(cover) : undefined,
               ownerName,
               ownerMid,
@@ -814,6 +820,7 @@ export const usePlayList = create<State & Action>()(
             })
             .map(item => ({
               ...item,
+              title: sanitizeTitle(item.title),
               id: idGenerator(),
             }));
 


### PR DESCRIPTION
## 问题描述

  播放列表中的歌曲标题显示异常，包含 HTML 标签代码（如 `<em>`, `</em>` 等），影响用户体验。

  ## 修复内容

  在播放列表的核心功能中添加了标题清理逻辑，确保所有歌曲标题在显示前都经过 HTML 标签过滤处理。

  ### 改动范围

  - ✅ `play` - 单曲播放时清理标题
  - ✅ `playList` - 批量播放列表时清理标题
  - ✅ `addToNext` - 添加到下一首时清理标题
  - ✅ `addList` - 添加列表时清理标题

  ### 技术实现

  使用现有的 `stripHtml` 工具函数对歌曲标题进行统一处理：
  ```typescript
  const sanitizeTitle = (title: string) => stripHtml(title);
  ```
  在所有涉及标题赋值的地方应用清理函数，确保：
  - 新增的歌曲标题干净无标签
  - 保持代码一致性和可维护性

  修改文件

  - src/store/play-list.ts - 播放列表状态管理


<img width="990" height="800" alt="image" src="https://github.com/user-attachments/assets/14cf68a5-2b9e-4ba6-acc4-225f041de57c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTML stripping for playlist titles to ensure proper display and prevent rendering issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->