### PR TITLE
feat: 为用户投稿页面添加全部播放按钮

### DIFF
--- a/src/pages/user-profile/post/index.tsx
+++ b/src/pages/user-profile/post/index.tsx
@@ -2,7 +2,9 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router";
 
 import { addToast, Spinner } from "@heroui/react";
+import { RiPlayFill } from "@remixicon/react";
 
+import AsyncButton from "@/components/async-button";
 import SearchWithSort from "@/components/search-with-sort";
 import { getSpaceWbiArcSearch, type SpaceArcVListItem } from "@/service/space-wbi-arc-search";
 import { useModalStore } from "@/store/modal";
@@ -151,20 +153,53 @@ const VideoPost: React.FC<VideoPostProps> = ({ getScrollElement }) => {
     }
   }, []);
 
+  const handlePlayAll = useCallback(async () => {
+    const playItems = items
+      .map(item => ({
+        type: "mv" as const,
+        bvid: item.bvid,
+        title: item.title,
+        cover: item.pic,
+        ownerName: item.author,
+        ownerMid: item.mid,
+      }))
+      .filter(item => Boolean(item.bvid));
+
+    if (!playItems.length) {
+      addToast({ title: "暂无可播放内容", color: "warning" });
+      return;
+    }
+
+    await usePlayList.getState().addList(playItems);
+    addToast({ title: `已添加 ${playItems.length} 个投稿到播放列表`, color: "success" });
+  }, [items]);
+
   return (
     <div className="h-full w-full">
       <div className="mb-4 flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
         <div className="text-default-500 pl-2 text-sm">共 {total} 个视频</div>
-        <SearchWithSort
-          onKeywordSearch={setKeyword}
-          order={order}
-          orderOptions={[
-            { key: "pubdate", label: "最新发布" },
-            { key: "click", label: "最多播放" },
-            { key: "stow", label: "最多收藏" },
-          ]}
-          onOrderChange={setOrder}
-        />
+        <div className="flex items-center gap-3">
+          <AsyncButton
+            color="primary"
+            size="sm"
+            startContent={<RiPlayFill size={18} />}
+            isDisabled={initialLoading || items.length === 0}
+            onPress={handlePlayAll}
+            className="dark:text-black"
+          >
+            全部播放
+          </AsyncButton>
+          <SearchWithSort
+            onKeywordSearch={setKeyword}
+            order={order}
+            orderOptions={[
+              { key: "pubdate", label: "最新发布" },
+              { key: "click", label: "最多播放" },
+              { key: "stow", label: "最多收藏" },
+            ]}
+            onOrderChange={setOrder}
+          />
+        </div>
       </div>
       {initialLoading ? (
         <div className="flex h-[280px] items-center justify-center">


### PR DESCRIPTION
为用户投稿视频列表添加"全部播放"功能，方便用户一键播放所有投稿视频。

## 功能说明

- 在投稿页面工具栏添加"全部播放"按钮
- 支持批量添加所有投稿视频到播放列表
- 自动过滤无效数据
- 加载中或列表为空时按钮自动禁用
- 添加成功后显示提示消息

## UI 改进

- 使用 AsyncButton 组件提供加载反馈
- 播放图标使用 RemixIcon 的 RiPlayFill
- 主色调按钮，深色模式下自动适配文字颜色
- 与搜索排序控件并排显示

## 交互优化

- 初始加载时禁用按钮
- 列表为空时禁用按钮
- 添加成功后显示 Toast 提示
- 提示消息显示添加数量

## 修改文件

- src/pages/user-profile/post/index.tsx - 添加全部播放功能

> **补充：**
> 1. 此项为针对 #181 的 issues 进行添加，基于此前提交的 全部播放  PR的逻辑；
> 2. 由于此播放器是对接的哔哩哔哩API，为避免弹验证码之类，只针对当前获取到的进行 全部播放，而不是针对所有投稿。


<img width="2400" height="1600" alt="image" src="https://github.com/user-attachments/assets/745d4ec2-05de-4033-a7a6-f9ecab62a263" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Play All" button to user profile post headers, enabling users to add all displayed items to their playlist in a single action. The button is disabled while content is loading or when no items are available, and displays confirmation messages upon completion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->