### PR TITLE
Feature/ycfcando optimize

### DIFF
--- a/src/components/menu/menu-fold.tsx
+++ b/src/components/menu/menu-fold.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Tooltip } from "@heroui/react";
 import clx from "classnames";
@@ -57,6 +57,15 @@ const MenuFold = <T = MenuItemProps,>({
       />
     );
   }, [items, collapsed, renderItem]);
+
+  /* 组件卸载时清理定时器 */
+  useEffect(() => {
+    return () => {
+      if (closeTimer.current) {
+        clearTimeout(closeTimer.current);
+      }
+    };
+  });
 
   return collapsed ? (
     <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>

--- a/src/components/menu/menu-fold.tsx
+++ b/src/components/menu/menu-fold.tsx
@@ -27,12 +27,13 @@ const MenuFold = <T = MenuItemProps,>({
   const [isHover, setIsHover] = useState(false);
 
   // 延迟关闭定时器（核心）
-  const closeTimer = useRef<NodeJS.Timeout | null>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // —————— 鼠标进入触发区 ——————
   const handleMouseEnter = () => {
     if (closeTimer.current) {
       clearTimeout(closeTimer.current); // 清除延迟
+      closeTimer.current = null;
     }
     setIsHover(true);
   };
@@ -63,6 +64,7 @@ const MenuFold = <T = MenuItemProps,>({
     return () => {
       if (closeTimer.current) {
         clearTimeout(closeTimer.current);
+        closeTimer.current = null;
       }
     };
   });

--- a/src/components/menu/menu-fold.tsx
+++ b/src/components/menu/menu-fold.tsx
@@ -1,0 +1,82 @@
+import { useMemo, useRef, useState } from "react";
+
+import { Tooltip } from "@heroui/react";
+import clx from "classnames";
+
+import type { MenuItemProps } from "./menu-item";
+
+import MenuGroup from "./menu-group";
+import MenuItem from "./menu-item";
+
+export interface MenuFoldProps<T = MenuItemProps> extends MenuItemProps {
+  /** 菜单项组 */
+  items: T[];
+  /* 是否折叠 */
+  isFolded: boolean;
+  renderItem?: (item: T, index: number) => React.ReactNode;
+}
+
+const MenuFold = <T = MenuItemProps,>({
+  items,
+  isFolded,
+  collapsed,
+  onPress,
+  renderItem,
+  ...menuItemProps
+}: MenuFoldProps<T>) => {
+  const [isHover, setIsHover] = useState(false);
+
+  // 延迟关闭定时器（核心）
+  const closeTimer = useRef<NodeJS.Timeout | null>(null);
+
+  // —————— 鼠标进入触发区 ——————
+  const handleMouseEnter = () => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current); // 清除延迟
+    }
+    setIsHover(true);
+  };
+
+  // —————— 鼠标离开触发区 ——————
+  const handleMouseLeave = () => {
+    // 延迟 100ms 关闭，给鼠标移动时间
+    closeTimer.current = setTimeout(() => {
+      setIsHover(false);
+    }, 100);
+  };
+
+  const menuGroup = useMemo(() => {
+    return (
+      <MenuGroup<T>
+        className={clx({
+          "pt-1 pl-2": !collapsed,
+        })}
+        items={items}
+        collapsed={collapsed}
+        renderItem={renderItem}
+      />
+    );
+  }, [items, collapsed, renderItem]);
+
+  return collapsed ? (
+    <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+      <Tooltip
+        classNames={{
+          content: ["w-15 overflow-hidden"],
+        }}
+        isOpen={isHover}
+        content={menuGroup}
+        placement="right"
+      >
+        <MenuItem collapsed={collapsed} {...(menuItemProps as MenuItemProps)} />
+      </Tooltip>
+    </div>
+  ) : (
+    <div>
+      <MenuItem collapsed={collapsed} onPress={onPress} {...(menuItemProps as MenuItemProps)} />
+      {!isFolded && menuGroup}
+    </div>
+  );
+};
+
+export default MenuFold;

--- a/src/components/menu/menu-group.tsx
+++ b/src/components/menu/menu-group.tsx
@@ -34,7 +34,7 @@ const MenuGroup = <T = MenuItemProps,>({ title, titleExtra, items, collapsed, cl
             return renderItem(item as T, index);
           }
           const { id, href, title } = item as MenuItemProps;
-          return <MenuItem key={(id as number) ?? href ?? title} {...(item as MenuItemProps)} collapsed={collapsed} />;
+          return <MenuItem key={id ?? href ?? title} {...(item as MenuItemProps)} collapsed={collapsed} />;
         })}
       </div>
     </div>

--- a/src/components/menu/menu-group.tsx
+++ b/src/components/menu/menu-group.tsx
@@ -2,18 +2,18 @@ import clx from "classnames";
 
 import MenuItem, { type MenuItemProps } from "../../components/menu/menu-item";
 
-interface Props {
+interface Props<T = MenuItemProps> {
   title?: React.ReactNode;
   titleExtra?: React.ReactNode;
-  items: MenuItemProps[];
+  items: Array<T>;
   collapsed?: boolean;
   className?: string;
-  renderItem?: (item: MenuItemProps, index: number) => React.ReactNode;
+  renderItem?: (item: T, index: number) => React.ReactNode;
 }
 
-const MenuGroup = ({ title, titleExtra, items, collapsed, className, renderItem }: Props) => {
+const MenuGroup = <T = MenuItemProps,>({ title, titleExtra, items, collapsed, className, renderItem }: Props<T>) => {
   return (
-    <>
+    <div>
       {!collapsed && Boolean(title) && (
         <div className="flex items-center justify-between p-2 text-sm text-zinc-500">
           <span>{title}</span>
@@ -22,22 +22,22 @@ const MenuGroup = ({ title, titleExtra, items, collapsed, className, renderItem 
       )}
       <div
         className={clx(
-          "flex flex-col items-stretch",
+          "flex flex-col items-stretch gap-1",
           {
             "px-2": collapsed,
           },
           className,
         )}
       >
-        {items.map((item, index) =>
-          renderItem ? (
-            renderItem(item, index)
-          ) : (
-            <MenuItem key={(item.id ?? item.href ?? item.title) as React.Key} {...item} collapsed={collapsed} />
-          ),
-        )}
+        {items.map((item, index) => {
+          if (renderItem) {
+            return renderItem(item as T, index);
+          }
+          const { id, href, title } = item as MenuItemProps;
+          return <MenuItem key={(id as number) ?? href ?? title} {...(item as MenuItemProps)} collapsed={collapsed} />;
+        })}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/components/menu/menu-item.tsx
+++ b/src/components/menu/menu-item.tsx
@@ -64,7 +64,10 @@ const MenuItem: React.FC<MenuItemProps> = ({
         radius="md"
         fallback={icon}
         alt={title}
-        className="h-10 w-10 flex-none"
+        className={clx("flex-none", {
+          "h-4.5 w-4.5": !collapsed,
+          "h-10 w-10": collapsed,
+        })}
       />
     );
   }, [cover, isActive, Icon, ActiveIcon, title, collapsed]);
@@ -87,7 +90,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
             "h-auto": collapsed,
             "text-primary": isActive,
           })}
-          {...(dndRest as any)}
+          {...(dndRest as Record<string, unknown>)}
         >
           {iconContent}
         </Button>
@@ -106,7 +109,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
       onPress={onPress}
       startContent={iconContent}
       className={twMerge("justify-start px-2 text-inherit", className, dndClassName)}
-      {...(dndRest as any)}
+      {...(dndRest as Record<string, unknown>)}
     >
       <span className="pointer-events-none truncate">{title}</span>
     </Button>

--- a/src/components/menu/menu-item.tsx
+++ b/src/components/menu/menu-item.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { useLocation, useParams } from "react-router";
 
-import { Avatar, Button, Link as HeroLink, Tooltip } from "@heroui/react";
+import { Button, Link as HeroLink, Avatar, Tooltip } from "@heroui/react";
 import clx from "classnames";
 import { twMerge } from "tailwind-merge";
 
@@ -10,19 +10,22 @@ export interface MenuItemProps {
   title: string;
   /** 菜单项链接 */
   href?: string;
-  /** 唯一标识，用于排序等场景 */
-  id?: number | string;
   /** 菜单项图标 */
   icon?: React.ComponentType<{ size?: number | string; className?: string }>;
   /** 封面 */
   cover?: string;
   /** 激活状态图标 */
   activeIcon?: React.ComponentType<{ size?: number | string; className?: string }>;
+  /** 菜单项样式 */
   className?: string;
+  /** 菜单项点击事件 */
   onPress?: VoidFunction;
+  /** 收缩菜单项 */
   collapsed?: boolean;
   /** 用于 dnd-kit 等场景，把拖拽监听器绑定到可交互元素上 */
   dndProps?: ({ className?: string } & Record<string, unknown>) | undefined;
+  /* 菜单项路径 用于匹配非跳转菜单 */
+  path?: string;
   [key: string]: unknown;
 }
 
@@ -35,85 +38,100 @@ const MenuItem: React.FC<MenuItemProps> = ({
   className,
   onPress,
   collapsed,
+  path,
   dndProps,
+  ...others
 }) => {
-  const location = useLocation();
-  const { id } = useParams();
-
-  const isActive = useMemo(() => {
-    return location.pathname === href || (id && href?.split("?")[0].includes(id));
-  }, [location.pathname, href, id]);
-
-  const iconContent = useMemo(() => {
-    const icon =
-      isActive && ActiveIcon ? (
-        <ActiveIcon size={18} className="text-primary" />
-      ) : Icon ? (
-        <Icon size={18} />
-      ) : undefined;
-
-    if (!collapsed && icon) {
-      return icon;
-    }
-
-    return (
-      <Avatar
-        name={title}
-        src={cover ? `${cover}@672w_378h_1c.avif` : undefined}
-        showFallback
-        radius="md"
-        fallback={icon}
-        alt={title}
-        className={clx("flex-none", {
-          "h-4.5 w-4.5": !collapsed,
-          "h-10 w-10": collapsed,
-        })}
-      />
-    );
-  }, [cover, isActive, Icon, ActiveIcon, title, collapsed]);
-
   const { className: dndClassName, ...dndRest } = (dndProps ?? {}) as {
     className?: string;
   } & Record<string, unknown>;
 
-  if (collapsed) {
+  const location = useLocation();
+  const { id } = useParams();
+
+  /* 菜单项激活状态 */
+  const isActive = useMemo(() => {
+    console.log(location.pathname);
     return (
-      <Tooltip closeDelay={0} content={title} placement="right" offset={-3}>
-        <Button
-          as={href ? HeroLink : "button"}
-          href={href}
-          fullWidth
-          variant={isActive ? "flat" : "light"}
-          color={isActive ? "primary" : "default"}
-          onPress={onPress}
-          className={clx("w-full min-w-0 justify-center rounded-md px-0 py-1", className, dndClassName, {
+      location.pathname === href ||
+      new RegExp(`^${path}`).test(location.pathname) ||
+      (id && href?.split("?")[0].includes(id))
+    );
+  }, [location.pathname, href, id, path]);
+
+  /* 菜单项图标 */
+  const menuIcon = useMemo(() => {
+    // Icon 存在
+    if (Icon) {
+      // 图标切换
+      const presentIcon =
+        isActive && ActiveIcon ? <ActiveIcon size={18} className="text-primary" /> : <Icon size={18} />;
+
+      // 是否折叠
+      return collapsed ? (
+        <Avatar className="h-10 w-10 flex-none" radius="md" fallback={presentIcon} alt={title} />
+      ) : (
+        presentIcon
+      );
+    }
+    // 没 Icon 使用 封面/首字
+    else {
+      return (
+        <Avatar
+          // 折叠 改变尺寸
+          className={clx("flex-none", {
+            "h-4 w-4": !collapsed,
+            "h-10 w-10": collapsed,
+          })}
+          name={title}
+          src={cover ? `${cover}@672w_378h_1c.avif` : undefined}
+          radius="md"
+          alt={title}
+        />
+      );
+    }
+  }, [Icon, title, cover, isActive, ActiveIcon, collapsed]);
+
+  const menuButton = useMemo(() => {
+    return (
+      <Button
+        as={href ? (HeroLink as any) : "button"}
+        href={href}
+        fullWidth
+        variant={isActive ? "flat" : "light"}
+        color={isActive ? "primary" : "default"}
+        onPress={onPress}
+        disableRipple={collapsed ? false : true}
+        startContent={collapsed ? undefined : menuIcon}
+        className={clx(
+          {
+            [twMerge("w-full min-w-0 justify-center rounded-md px-0 py-1")]: collapsed,
+            [twMerge("justify-start px-2 text-inherit")]: !collapsed,
+          },
+          className,
+          dndClassName,
+          {
             "h-auto": collapsed,
             "text-primary": isActive,
-          })}
-          {...(dndRest as Record<string, unknown>)}
-        >
-          {iconContent}
-        </Button>
+          },
+        )}
+        {...(dndRest as Record<string, unknown>)}
+        {...others}
+      >
+        {collapsed ? menuIcon : <span className="pointer-events-none truncate">{title}</span>}
+      </Button>
+    );
+  }, [className, collapsed, dndClassName, dndRest, href, isActive, menuIcon, onPress, others, title]);
+
+  if (collapsed) {
+    return (
+      <Tooltip content={title} placement="right">
+        {menuButton}
       </Tooltip>
     );
   }
 
-  return (
-    <Button
-      as={href ? HeroLink : "button"}
-      href={href}
-      fullWidth
-      disableRipple
-      variant={isActive ? "flat" : "light"}
-      color={isActive ? "primary" : "default"}
-      onPress={onPress}
-      startContent={iconContent}
-      className={twMerge("justify-start px-2 text-inherit", className, dndClassName)}
-      {...(dndRest as Record<string, unknown>)}
-    >
-      <span className="pointer-events-none truncate">{title}</span>
-    </Button>
-  );
+  return menuButton;
 };
 
 export default MenuItem;

--- a/src/components/menu/menu-item.tsx
+++ b/src/components/menu/menu-item.tsx
@@ -6,6 +6,8 @@ import clx from "classnames";
 import { twMerge } from "tailwind-merge";
 
 export interface MenuItemProps {
+  /** 菜单项 id */
+  id?: string | number;
   /** 菜单项标签 */
   title: string;
   /** 菜单项链接 */
@@ -51,10 +53,9 @@ const MenuItem: React.FC<MenuItemProps> = ({
 
   /* 菜单项激活状态 */
   const isActive = useMemo(() => {
-    console.log(location.pathname);
     return (
       location.pathname === href ||
-      new RegExp(`^${path}`).test(location.pathname) ||
+      (path && location.pathname.startsWith(path)) ||
       (id && href?.split("?")[0].includes(id))
     );
   }, [location.pathname, href, id, path]);
@@ -93,6 +94,9 @@ const MenuItem: React.FC<MenuItemProps> = ({
   }, [Icon, title, cover, isActive, ActiveIcon, collapsed]);
 
   const menuButton = useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { id: _, ...restOthers } = others;
+
     return (
       <Button
         as={href ? (HeroLink as any) : "button"}
@@ -116,7 +120,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
           },
         )}
         {...(dndRest as Record<string, unknown>)}
-        {...others}
+        {...restOthers}
       >
         {collapsed ? menuIcon : <span className="pointer-events-none truncate">{title}</span>}
       </Button>

--- a/src/components/menu/menu-item.tsx
+++ b/src/components/menu/menu-item.tsx
@@ -53,10 +53,11 @@ const MenuItem: React.FC<MenuItemProps> = ({
 
   /* 菜单项激活状态 */
   const isActive = useMemo(() => {
+    const hrefPath = href?.split("?")[0];
     return (
-      location.pathname === href ||
-      (path && location.pathname.startsWith(path)) ||
-      (id && href?.split("?")[0].includes(id))
+      location.pathname === hrefPath ||
+      (path ? location.pathname === path || location.pathname.startsWith(`${path}/`) : false) ||
+      (id ? hrefPath?.endsWith(`/${id}`) : false)
     );
   }, [location.pathname, href, id, path]);
 

--- a/src/layout/side/collection/index.tsx
+++ b/src/layout/side/collection/index.tsx
@@ -1,31 +1,38 @@
-import { useCallback, useEffect, useMemo, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import {
+  closestCenter,
   DndContext,
   type DragEndEvent,
-  closestCenter,
   KeyboardSensor,
   PointerSensor,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
 import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import { Button, Tooltip, addToast } from "@heroui/react";
+import { addToast } from "@heroui/react";
 import {
-  RiAddLine,
-  RiArrowDownSLine,
   RiDeleteBinLine,
   RiEdit2Line,
   RiEyeOffLine,
+  RiFolderAddLine,
   RiPlayCircleLine,
   RiPlayListAddLine,
   RiStarOffLine,
+  RiStarSmileLine,
+  RiStarSmileFill,
+  RiStackLine,
+  RiStackFill,
 } from "@remixicon/react";
+
+import type { MenuItemProps } from "@/components/menu/menu-item";
 
 import { CollectionType } from "@/common/constants/collection";
 import { getAllFavMedia } from "@/common/utils/fav";
 import { type ContextMenuItem } from "@/components/context-menu";
+import MenuFold from "@/components/menu/menu-fold";
 import MenuGroup from "@/components/menu/menu-group";
+import MenuItem from "@/components/menu/menu-item";
 import SortableMenuItem from "@/layout/side/collection/sortable-menu-item";
 import { postFavFolderDel } from "@/service/fav-folder-del";
 import { postFavFolderUnfav } from "@/service/fav-folder-unfav";
@@ -50,6 +57,15 @@ interface CollectionMenuItem {
   className: string;
   type?: number;
   mid?: number;
+}
+
+interface CollectionMenu extends MenuItemProps {
+  items: CollectionMenuItem[] | [MenuItemProps, ...CollectionMenuItem[]];
+  isFolded: boolean;
+  isDragEnabled: boolean;
+  onDragEnd: (event: DragEndEvent) => void;
+  contextMenuItems: ContextMenuItem[];
+  onContextMenuAction: (action: string, item: CollectionMenuItem) => void;
 }
 
 const Collection = ({ isCollapsed, onOpenAddFavorite, onOpenEditFavorite }: Props) => {
@@ -117,9 +133,12 @@ const Collection = ({ isCollapsed, onOpenAddFavorite, onOpenEditFavorite }: Prop
 
   const filteredCollectedFavorites = collectedFavorites.filter(item => !hiddenMenuKeys.includes(String(item.id)));
   const filteredCreatedFavorites = createdFavorites.filter(item => !hiddenMenuKeys.includes(String(item.id)));
-  const isDragEnabled = !isCollapsed;
-  const isCreatedDragEnabled = isDragEnabled && !createdFolded;
-  const isCollectedDragEnabled = isDragEnabled && !collectedFolded;
+  const isDragEnabled = isCollapsed;
+  const isCreatedDragEnabled = isDragEnabled || !createdFolded;
+  const isCollectedDragEnabled = isDragEnabled || !collectedFolded;
+
+  console.log(isDragEnabled, createdFolded);
+
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
@@ -361,192 +380,156 @@ const Collection = ({ isCollapsed, onOpenAddFavorite, onOpenEditFavorite }: Prop
     ],
   );
 
-  const handleCreatedDragEnd = (event: DragEndEvent) => {
-    if (isCollapsed || createdFolded) {
-      return;
-    }
+  const handleCreatedDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      if (!isCreatedDragEnabled) {
+        return;
+      }
 
-    const { active, over } = event;
+      const { active, over } = event;
 
-    if (!over || active.id === over.id) {
-      return;
-    }
+      if (!over || active.id === over.id) {
+        return;
+      }
 
-    reorderCreatedFavorites(Number(active.id), Number(over.id));
-  };
+      reorderCreatedFavorites(Number(active.id), Number(over.id));
+    },
+    [isCreatedDragEnabled, reorderCreatedFavorites],
+  );
 
-  const handleCollectedDragEnd = (event: DragEndEvent) => {
-    if (isCollapsed || collectedFolded) {
-      return;
-    }
+  const handleCollectedDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      if (!isCollectedDragEnabled) {
+        return;
+      }
 
-    const { active, over } = event;
+      const { active, over } = event;
 
-    if (!over || active.id === over.id) {
-      return;
-    }
+      if (!over || active.id === over.id) {
+        return;
+      }
 
-    reorderCollectedFavorites(Number(active.id), Number(over.id));
-  };
+      reorderCollectedFavorites(Number(active.id), Number(over.id));
+    },
+    [isCollectedDragEnabled, reorderCollectedFavorites],
+  );
 
-  const renderFavoriteGroup = ({
-    title,
-    items,
-    isFolded,
-    onToggleFolded,
-    titleExtra,
-    isDragEnabled: isGroupDragEnabled,
-    onDragEnd,
-    contextMenuItems,
-    onContextMenuAction,
-  }: {
-    title: string;
-    items: CollectionMenuItem[];
-    isFolded: boolean;
-    onToggleFolded: () => void;
-    titleExtra?: ReactNode;
-    isDragEnabled: boolean;
-    onDragEnd: (event: DragEndEvent) => void;
-    contextMenuItems: ContextMenuItem[];
-    onContextMenuAction: (action: string, item: CollectionMenuItem) => void;
-  }) => {
-    if (!items.length) {
-      return null;
-    }
-
-    const header = !isCollapsed ? (
-      <div className="flex items-center justify-between p-2 text-sm text-zinc-500">
-        <button
-          type="button"
-          aria-expanded={!isFolded}
-          onClick={onToggleFolded}
-          className="hover:text-foreground flex items-center gap-1 text-sm text-zinc-500 transition-colors"
-        >
-          <RiArrowDownSLine size={16} className={`transition-transform ${isFolded ? "-rotate-90" : "rotate-0"}`} />
-          <span className="whitespace-nowrap">{title}</span>
-        </button>
-        {titleExtra}
-      </div>
-    ) : null;
-
-    if (isFolded) {
-      return header;
-    }
-
-    const group = (
-      <>
-        {header}
-        <MenuGroup
-          items={items}
-          collapsed={isCollapsed}
-          renderItem={item => (
-            <SortableMenuItem
-              key={item.id}
-              id={item.id}
-              collapsed={isCollapsed}
-              disabled={!isGroupDragEnabled}
-              contextMenuItems={contextMenuItems}
-              onContextMenuAction={action => onContextMenuAction(action, item)}
-              {...item}
-            />
-          )}
-        />
-      </>
-    );
-
-    if (!isGroupDragEnabled) {
-      return group;
-    }
-
-    return (
-      <DndContext collisionDetection={closestCenter} onDragEnd={onDragEnd} sensors={sensors}>
-        <SortableContext items={items.map(item => item.id)} strategy={verticalListSortingStrategy}>
-          {group}
-        </SortableContext>
-      </DndContext>
-    );
-  };
-
-  const renderCreatedGroup = () => {
-    if (!user?.isLogin) {
-      return null;
-    }
-
-    const items = filteredCreatedFavorites.map(item => ({
-      id: item.id,
-      title: item.title,
-      href: `/collection/${item.id}?mid=${item?.mid}`,
-      cover: item.cover,
-      className: "px-2 py-1 h-auto",
-      type: item.type,
-      mid: item.mid,
-    }));
-
-    const titleExtra = onOpenAddFavorite ? (
-      <Tooltip closeDelay={0} content="新建收藏夹">
-        <Button
-          isIconOnly
-          variant="light"
-          radius="md"
-          size="sm"
-          className="h-auto w-auto min-w-auto p-1"
-          onPress={onOpenAddFavorite}
-        >
-          <RiAddLine size={16} />
-        </Button>
-      </Tooltip>
-    ) : null;
-
-    return renderFavoriteGroup({
-      title: "我创建的",
-      items,
-      isFolded: createdFolded,
-      onToggleFolded: handleToggleCreatedFolded,
-      titleExtra,
-      isDragEnabled: isCreatedDragEnabled,
-      onDragEnd: handleCreatedDragEnd,
-      contextMenuItems: createdContextMenus,
-      onContextMenuAction: (action, item) =>
-        handleCreatedMenuAction(action, {
+  const menuList = useMemo<CollectionMenu[]>(
+    () => [
+      {
+        title: "我的收藏",
+        icon: RiStarSmileLine,
+        activeIcon: RiStarSmileFill,
+        path: "/collection",
+        items: [
+          {
+            title: "新建收藏",
+            icon: RiFolderAddLine,
+            onPress: onOpenAddFavorite,
+            className: "px-2 py-1 h-auto",
+          },
+          ...filteredCreatedFavorites.map(item => ({
+            id: item.id,
+            title: item.title,
+            href: `/collection/${item.id}?mid=${item?.mid}`,
+            cover: item.cover,
+            className: "px-2 py-1 h-auto",
+            type: item.type,
+            mid: item.mid,
+          })),
+        ],
+        isFolded: createdFolded,
+        onPress: handleToggleCreatedFolded,
+        isDragEnabled: isCreatedDragEnabled,
+        onDragEnd: handleCreatedDragEnd,
+        contextMenuItems: createdContextMenus,
+        onContextMenuAction: (action, item) =>
+          handleCreatedMenuAction(action, {
+            id: item.id,
+            title: item.title,
+          }),
+      },
+      {
+        title: "我的合集",
+        icon: RiStackLine,
+        activeIcon: RiStackFill,
+        path: "/compilation",
+        items: filteredCollectedFavorites.map(item => ({
           id: item.id,
           title: item.title,
-        }),
-    });
-  };
-
-  const renderCollectedGroup = () => {
-    const items = filteredCollectedFavorites.map(item => ({
-      id: item.id,
-      title: item.title,
-      href: `/collection/${item.id}?type=${item.type}&mid=${item?.mid}`,
-      cover: item.cover,
-      className: "px-2 py-1 h-auto",
-      type: item.type,
-      mid: item.mid,
-    }));
-
-    return renderFavoriteGroup({
-      title: "我收藏的",
-      items,
-      isFolded: collectedFolded,
-      onToggleFolded: handleToggleCollectedFolded,
-      isDragEnabled: isCollectedDragEnabled,
-      onDragEnd: handleCollectedDragEnd,
-      contextMenuItems: collectedContextMenus,
-      onContextMenuAction: (action, item) =>
-        handleCollectedMenuAction(action, {
-          id: item.id,
-          title: item.title,
+          href: `/compilation/${item.id}?type=${item.type}&mid=${item?.mid}`,
+          cover: item.cover,
+          className: "px-2 py-1 h-auto",
           type: item.type,
-        }),
-    });
-  };
+          mid: item.mid,
+        })),
+        isFolded: collectedFolded,
+        onPress: handleToggleCollectedFolded,
+        isDragEnabled: isCollectedDragEnabled,
+        onDragEnd: handleCollectedDragEnd,
+        contextMenuItems: collectedContextMenus,
+        onContextMenuAction: (action, item) =>
+          handleCollectedMenuAction(action, {
+            id: item.id,
+            title: item.title,
+            type: item.type,
+          }),
+      },
+    ],
+    [
+      collectedContextMenus,
+      collectedFolded,
+      createdContextMenus,
+      createdFolded,
+      filteredCollectedFavorites,
+      filteredCreatedFavorites,
+      handleCollectedDragEnd,
+      handleCollectedMenuAction,
+      handleCreatedDragEnd,
+      handleCreatedMenuAction,
+      handleToggleCollectedFolded,
+      handleToggleCreatedFolded,
+      isCollectedDragEnabled,
+      isCreatedDragEnabled,
+      onOpenAddFavorite,
+    ],
+  );
 
   return (
-    <>
-      {renderCreatedGroup()}
-      {renderCollectedGroup()}
-    </>
+    <MenuGroup<CollectionMenu>
+      collapsed={isCollapsed}
+      items={menuList}
+      renderItem={({ isDragEnabled, contextMenuItems, onContextMenuAction, onDragEnd, items, ...otherProps }) => (
+        <DndContext collisionDetection={closestCenter} onDragEnd={onDragEnd} sensors={sensors}>
+          <SortableContext
+            items={(items as CollectionMenuItem[]).filter(item => item.id).map(item => item.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <MenuFold<CollectionMenuItem>
+              items={items as CollectionMenuItem[]}
+              collapsed={isCollapsed}
+              renderItem={(item, index) => {
+                const { id, ...otherProps } = item;
+                return id ? (
+                  <SortableMenuItem
+                    key={id}
+                    id={id}
+                    collapsed={isCollapsed}
+                    disabled={!isDragEnabled}
+                    contextMenuItems={contextMenuItems}
+                    onContextMenuAction={action => onContextMenuAction(action, item as CollectionMenuItem)}
+                    {...otherProps}
+                  />
+                ) : (
+                  <MenuItem key={index} {...(otherProps as MenuItemProps)} collapsed={isCollapsed} />
+                );
+              }}
+              {...otherProps}
+            />
+          </SortableContext>
+        </DndContext>
+      )}
+    />
   );
 };
 

--- a/src/layout/side/collection/index.tsx
+++ b/src/layout/side/collection/index.tsx
@@ -137,8 +137,6 @@ const Collection = ({ isCollapsed, onOpenAddFavorite, onOpenEditFavorite }: Prop
   const isCreatedDragEnabled = isDragEnabled || !createdFolded;
   const isCollectedDragEnabled = isDragEnabled || !collectedFolded;
 
-  console.log(isDragEnabled, createdFolded);
-
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {

--- a/src/layout/side/default-menu/index.tsx
+++ b/src/layout/side/default-menu/index.tsx
@@ -1,7 +1,5 @@
 import React, { useMemo } from "react";
 
-import { RiApps2AddFill, RiApps2AddLine } from "@remixicon/react";
-
 import { DefaultMenuList } from "@/common/constants/menus";
 import MenuGroup from "@/components/menu/menu-group";
 import { useSettings } from "@/store/settings";
@@ -9,10 +7,9 @@ import { useUser } from "@/store/user";
 
 interface Props {
   isCollapsed?: boolean;
-  onOpenAddFavorite?: () => void;
 }
 
-const DefaultMenus = ({ isCollapsed, onOpenAddFavorite }: Props) => {
+const DefaultMenus = ({ isCollapsed }: Props) => {
   const user = useUser(state => state.user);
   const hiddenMenuKeys = useSettings(state => state.hiddenMenuKeys);
 
@@ -21,20 +18,8 @@ const DefaultMenus = ({ isCollapsed, onOpenAddFavorite }: Props) => {
       item => item.href && !hiddenMenuKeys.includes(item.href),
     );
 
-    if (isCollapsed) {
-      return [
-        ...filtered,
-        {
-          title: "创建收藏夹",
-          icon: RiApps2AddLine,
-          activeIcon: RiApps2AddFill,
-          onPress: onOpenAddFavorite,
-        },
-      ];
-    }
-
     return filtered;
-  }, [user?.isLogin, hiddenMenuKeys, isCollapsed, onOpenAddFavorite]);
+  }, [user?.isLogin, hiddenMenuKeys]);
 
   return <MenuGroup items={items} collapsed={isCollapsed} />;
 };

--- a/src/layout/side/index.tsx
+++ b/src/layout/side/index.tsx
@@ -155,12 +155,14 @@ const SideNav = () => {
             "overflow-hidden": isDragging,
           })}
         >
-          <DefaultMenus isCollapsed={isCollapsedVisual} onOpenAddFavorite={handleOpenAddFavorite} />
-          <Collection
-            isCollapsed={isCollapsedVisual}
-            onOpenAddFavorite={handleOpenAddFavorite}
-            onOpenEditFavorite={handleOpenEditFavorite}
-          />
+          <div className="flex flex-col gap-1">
+            <DefaultMenus isCollapsed={isCollapsedVisual} />
+            <Collection
+              isCollapsed={isCollapsedVisual}
+              onOpenAddFavorite={handleOpenAddFavorite}
+              onOpenEditFavorite={handleOpenEditFavorite}
+            />
+          </div>
         </ScrollContainer>
         <Button
           size="sm"

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -42,6 +42,10 @@ const routes: RouteObject[] = [
         element: <Folder />,
       },
       {
+        path: "compilation/:id",
+        element: <Folder />,
+      },
+      {
         path: "user/:id",
         element: <UserProfile />,
       },


### PR DESCRIPTION
1. 将侧边栏样式统一（Icon的尺寸统一、我收藏的&我创建的样式统一）
2. 对侧边栏收起时，我收藏的&我创建的交互修改（采用hover在右侧浮现内容）
3. 支持了选中收藏时，我收藏的&我创建的选中高亮
4. 统一了创建收藏夹交互逻辑（将创建收藏夹入口移至内部）
![20260402-065935](https://github.com/user-attachments/assets/b8901595-229b-4440-87b4-efafe476ea41)
![20260402-070355](https://github.com/user-attachments/assets/0c0a967a-99e7-486c-8e47-f87089ecb1ea)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible menu sections now show a preview tooltip when folded.
  * New route to open a compilation-specific folder view by ID.

* **Improvements**
  * Unified collection menus with improved drag-and-drop sorting and clearer fold behavior.
  * Refined menu item visuals: icon/avatar handling, spacing, and active-state detection.
  * Side menu layout spacing adjusted; removed the extra "create favorite" entry in collapsed mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->